### PR TITLE
Changed About Page Repository Link

### DIFF
--- a/app/src/main/scala/im/tox/antox/activities/About.scala
+++ b/app/src/main/scala/im/tox/antox/activities/About.scala
@@ -18,7 +18,7 @@ class About extends ActionBarActivity {
     getSupportActionBar.setDisplayHomeAsUpEnabled(true)
     val tw = findViewById(R.id.textView).asInstanceOf[TextView]
     val tw10 = findViewById(R.id.textView10).asInstanceOf[TextView]
-    val pattern = Pattern.compile("https://github.com/Astonex/Antox")
+    val pattern = Pattern.compile("https://github.com/subliun/Antox")
     Linkify.addLinks(tw10, pattern, "")
     var version = "-.-.-"
     try {


### PR DESCRIPTION
The About page is pretty outdated, it should get regular checks to make sure testers are updated on new features and plans.

I only updated the link, the new developer should update the About page as he decides. I'd mention at least the port to tox4j of Astonex's repo.