### PR TITLE
Fix language setting bug for Chinese

### DIFF
--- a/app/src/main/res/values/strings_activity_settings.xml
+++ b/app/src/main/res/values/strings_activity_settings.xml
@@ -82,7 +82,7 @@
         <item>sr</item>
         <item>uk</item>
         <item>pt</item>
-        <item>cn</item>
+        <item>zh_CN</item>
     </string-array>
 
     <!-- Menu strings -->

--- a/app/src/main/res/xml/settings_main.xml
+++ b/app/src/main/res/xml/settings_main.xml
@@ -30,7 +30,7 @@
             android:defaultValue="-1"
             android:entries="@array/pref_language_list_titles"
             android:entryValues="@array/pref_language_list_values"
-            android:key="language"
+            android:key="locale"
             android:negativeButtonText="@null"
             android:positiveButtonText="@null"
             android:title="@string/pref_title_language" />

--- a/app/src/main/scala/im/tox/antox/activities/MainActivity.scala
+++ b/app/src/main/scala/im/tox/antox/activities/MainActivity.scala
@@ -102,14 +102,24 @@ class MainActivity extends ActionBarActivity {
     setVolumeControlStream(AudioManager.STREAM_VOICE_CALL)
 
     // Set the right language
-    val language = preferences.getString("language", "-1")
-    if (language == "-1") {
+    val localeStr = preferences.getString("locale", "-1")
+    if (localeStr == "-1") {
       val editor = preferences.edit()
-      val currentLanguage = getResources.getConfiguration.locale.getCountry.toLowerCase
-      editor.putString("language", currentLanguage)
+      val currentLanguage = getResources.getConfiguration.locale.getLanguage.toLowerCase
+      val currentCountry = getResources.getConfiguration.locale.getCountry
+      editor.putString("locale", currentLanguage + "_" + currentCountry)
       editor.apply()
     } else {
-      val locale = new Locale(language)
+      var locale = getResources.getConfiguration.locale
+      val spliteLocation = localeStr.indexOf("_")
+
+      if (spliteLocation != -1) {
+        val languageStr = localeStr.substring(0, spliteLocation)
+        val countryStr = localeStr.substring(spliteLocation + 1)
+        locale = new Locale(languageStr, countryStr)
+      } else {
+        locale = new Locale(localeStr)
+      }
       Locale.setDefault(locale)
       val config = new Configuration()
       config.locale = locale

--- a/app/src/main/scala/im/tox/antox/activities/Settings.scala
+++ b/app/src/main/scala/im/tox/antox/activities/Settings.scala
@@ -47,7 +47,7 @@ class Settings extends PreferenceActivity with SharedPreferences.OnSharedPrefere
       getActionBar != null) {
       getActionBar.setDisplayHomeAsUpEnabled(true)
     }
-    bindPreferenceSummaryToValue(findPreference("language"))
+    bindPreferenceSummaryToValue(findPreference("locale"))
     val nospamPreference = findPreference("nospam")
     nospamPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
 
@@ -98,7 +98,7 @@ class Settings extends PreferenceActivity with SharedPreferences.OnSharedPrefere
         antoxDB.close()
       }
     }
-    if (key == "language") {
+    if (key == "locale") {
       val intent = getBaseContext.getPackageManager.getLaunchIntentForPackage(getBaseContext.getPackageName)
       intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
       startActivity(intent)


### PR DESCRIPTION
There are two country code for Chinese, "zh_CN" and "zh_TW".  And have to be init with the country code. Or language will fallback to default en_US.