### PR TITLE
Temporary removal of repo.tox.im repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Antox is an Android 2.3+ client for Tox. It aims to bring the full multimedia su
 
 To get Antox on Google Play, join the [Google+ Community](https://plus.google.com/communities/103125800027884896310), and follow the instructions given.
 
-To install on F-Droid, add https://repo.tox.im/android and search for "Antox".
-
 ###What Is Currently Working
 - One to one messaging
 - File transfers


### PR DESCRIPTION
As it was stated in recent blog post on https://blog.tox.chat/2015/07/current-situation-3/
"Unfortunately, Sean refuses to take responsibility for what he has done, and seems to carry the attitude that what he did was perfectly acceptable. Despite our having spent a great deal of time and effort trying to engage with him, giving him opportunities to pay us back and redeem himself (which is part of the reason why we have waited this long to make an official post about it), he has shown no remorse for his actions, and continues to hold some of our infrastructure “hostage”. This includes the tox.im, toxme.se, and libtoxcore.so domains. For this reason, we have also been forced to disassociate ourselves with the aforementioned domains and begin again from scratch with a new domain, tox.chat"