### PR TITLE
Use sample size for avatar images, fix formatting, add extra debugging

### DIFF
--- a/app/src/main/scala/chat/tox/antox/fragments/AvatarDialog.scala
+++ b/app/src/main/scala/chat/tox/antox/fragments/AvatarDialog.scala
@@ -17,7 +17,6 @@ import android.widget.{Button, ImageView, Toast}
 import chat.tox.antox.R
 import chat.tox.antox.data.State
 import chat.tox.antox.utils.{BitmapManager, Constants, FileUtils}
-import chat.tox.antox.wrapper.BitmapUtils
 import chat.tox.antox.wrapper.BitmapUtils.RichBitmap
 import chat.tox.antox.wrapper.FileKind.AVATAR
 
@@ -63,7 +62,11 @@ class AvatarDialog(activity: Activity) {
   }
 
   def resizeAvatar(avatar: File): Option[Bitmap] = {
-    val rawBitmap = BitmapFactory.decodeFile(avatar.getPath)
+    val options = new BitmapFactory.Options()
+    options.inSampleSize = BitmapManager.calculateInSampleSize(options, 256)
+    options.inPreferredConfig = Bitmap.Config.RGB_565
+    options.inJustDecodeBounds = false
+    val rawBitmap = BitmapFactory.decodeFile(avatar.getPath, options)
     val cropDimension =
       if (rawBitmap.getWidth >= rawBitmap.getHeight) {
         rawBitmap.getHeight

--- a/app/src/main/scala/chat/tox/antox/utils/BitmapManager.scala
+++ b/app/src/main/scala/chat/tox/antox/utils/BitmapManager.scala
@@ -68,7 +68,7 @@ object BitmapManager {
     mAvatarValid.put(key, false)
   }
 
-  private def calculateInSampleSize(options: BitmapFactory.Options, reqWidth: Int): Int = {
+  def calculateInSampleSize(options: BitmapFactory.Options, reqWidth: Int): Int = {
     val width = options.outWidth
     var inSampleSize = 1
 

--- a/app/src/main/scala/chat/tox/antox/utils/BitmapManager.scala
+++ b/app/src/main/scala/chat/tox/antox/utils/BitmapManager.scala
@@ -78,6 +78,7 @@ object BitmapManager {
         inSampleSize *= 2
       }
     }
+    Log.d("BitMapManager", "Using a sample size of " + inSampleSize)
 
     inSampleSize
   }
@@ -98,7 +99,7 @@ object BitmapManager {
    */
   private def getBytesFromStream(inputStream: InputStream): Array[Byte] = {
     var byteArr = Array.ofDim[Byte](0)
-    val buffer = Array.ofDim[Byte](2^10)
+    val buffer = Array.ofDim[Byte](2 ^ 10)
     var len: Int = 0
     var count = 0
 
@@ -138,7 +139,7 @@ object BitmapManager {
       // Get the bytes from the image file
       val byteArr = getBytesFromStream(fis)
 
-      val options = new BitmapOptions()
+      val options = new BitmapFactory.Options()
 
       if (!decodeAndCheck(byteArr, options)) {
         return null
@@ -175,25 +176,28 @@ object BitmapManager {
     val poolSize = 100
     val poolTimeout = 1000
     ExecutionContext.fromExecutor(
-    new ThreadPoolExecutor(poolSize, poolSize, poolTimeout, TimeUnit.SECONDS, new LinkedBlockingQueue[Runnable])
-  )}
+      new ThreadPoolExecutor(poolSize, poolSize, poolTimeout, TimeUnit.SECONDS, new LinkedBlockingQueue[Runnable])
+    )
+  }
 
   def load(file: File, imageView: ImageView, isAvatar: Boolean) {
-      val imageKey = file.getPath + file.getName
+    val imageKey = file.getPath + file.getName
 
-      getFromCache(isAvatar, imageKey) match {
-        case Some(bitmap) =>
-          imageView.setImageBitmap(bitmap)
+    getFromCache(isAvatar, imageKey) match {
+      case Some(bitmap) =>
+        Log.d("BitmapManager", "Loading Bitmap image from cache")
+        imageView.setImageBitmap(bitmap)
 
-        case None =>
-          Future {
-            val bitmap = decodeBitmap(file, imageKey, isAvatar)
+      case None =>
+        Log.d("BitmapManager", "Decoding Bitmap image")
+        Future {
+          val bitmap = decodeBitmap(file, imageKey, isAvatar)
 
-            if (bitmap != null) {
-              runOnUiThread(imageView.setImageBitmap(bitmap))
-            }
+          if (bitmap != null) {
+            runOnUiThread(imageView.setImageBitmap(bitmap))
           }
-      }
+        }
+    }
   }
 }
 


### PR DESCRIPTION
Avatars were not being scaled down after a picture was taken causing an OOM error on low-end devices. 256px still seems like a lot, and the memory usage still seems to double ~18MB -> ~45MB
but this is faster and way more memory efficient