### PR TITLE
Remove protobuf from dependency scripts

### DIFF
--- a/download-dependencies.bat
+++ b/download-dependencies.bat
@@ -9,6 +9,7 @@ DEL /F /Q app/src/main/jniLibs/armeabi/libtox4j.so
 DEL /F /Q app/src/main/jniLibs/x86/libtox4j.so
 DEL /F /Q app/src/main/jniLibs/arm64-v8a/libtox4j.so
 
+echo "Downloading latest version: libtox4j.so"
 powershell -Command "(New-Object Net.WebClient).DownloadFile('https://build.tox.chat/job/tox4j_build_android_armel_release/lastSuccessfulBuild/artifact/artifacts/libtox4j.so', 'app\src\main\jniLibs\armeabi\libtox4j.so')"
 powershell -Command "(New-Object Net.WebClient).DownloadFile('https://build.tox.chat/job/tox4j_build_android_x86_release/lastSuccessfulBuild/artifact/artifacts/libtox4j.so', 'app\src\main\jniLibs\x86\libtox4j.so')"
 powershell -Command "(New-Object Net.WebClient).DownloadFile('https://build.tox.chat/job/tox4j_build_android_arm64_release/lastSuccessfulBuild/artifact/artifacts/libtox4j.so', 'app\src\main\jniLibs\arm64-v8a\libtox4j.so')"
@@ -17,6 +18,7 @@ DEL /F /Q app/src/main/jniLibs/armeabi/libkaliumjni.so
 DEL /F /Q app/src/main/jniLibs/x86/libkaliumjni.so
 DEL /F /Q app/src/main/jniLibs/arm64-v8a/libkaliumjni.so
 
+echo "Downloading latest version: libkaliumjni.so"
 powershell -Command "(New-Object Net.WebClient).DownloadFile('https://build.tox.chat/job/libkaliumjni_build_android_armel_static_release/lastSuccessfulBuild/artifact/kalium-jni/jni/libkaliumjni.so', 'app\src\main\jniLibs\armeabi\libkaliumjni.so')"
 powershell -Command "(New-Object Net.WebClient).DownloadFile('https://build.tox.chat/job/libkaliumjni_build_android_x86_static_release/lastSuccessfulBuild/artifact/kalium-jni/jni/libkaliumjni.so', 'app\src\main\jniLibs\x86\libkaliumjni.so')"
 powershell -Command "(New-Object Net.WebClient).DownloadFile('https://build.tox.chat/job/libkaliumjni_build_android_arm64_static_release/lastSuccessfulBuild/artifact/kalium-jni/jni/libkaliumjni.so', 'app\src\main\jniLibs\arm64-v8a\libkaliumjni.so')"
@@ -27,10 +29,6 @@ echo "Removed old version: tox4j_2.11.jar"
 echo "Downloading latest version: tox4j_2.11.jar"
 powershell -Command "(New-Object Net.WebClient).DownloadFile('https://build.tox.chat/job/tox4j_build_android_armel_release/lastSuccessfulBuild/artifact/artifacts/tox4j_2.11-0.1-SNAPSHOT.jar', 'app\libs\tox4j_2.11.jar')"
 echo "Downloaded."
-DEL /F /Q app\libs\protobuf-java-2.6.1.jar
-echo "Removed old version: protobuf-java-2.6.1.jar"
-echo "Downloading latest version: protobuf-java-2.6.1.jar"
-powershell -Command "(New-Object Net.WebClient).DownloadFile('https://build.tox.chat/job/protobuf_build_android_armel_release/lastSuccessfulBuild/artifact/protobuf.jar', 'app\libs\protobuf-java-2.6.1.jar')"
-
 echo "...Finished!"
+pause
 @echo ON

--- a/download-dependencies.sh
+++ b/download-dependencies.sh
@@ -23,6 +23,3 @@ cd ${0%/*}
 mkdir -p app/libs
 rm app/libs/tox4j_2.11.jar
 wget https://build.tox.chat/job/tox4j_build_android_armel_release/lastSuccessfulBuild/artifact/artifacts/tox4j_2.11-0.1-SNAPSHOT.jar -O app/libs/tox4j_2.11.jar
-rm app/libs/protobuf-java-2.6.1.jar
-wget https://build.tox.chat/job/protobuf_build_android_armel_release/lastSuccessfulBuild/artifact/protobuf.jar -O app/libs/protobuf-java-2.6.1.jar
-


### PR DESCRIPTION
Protobuf is not used and can be obtained from maven if needed