### PR TITLE
Added compatibility for Jelly Bean and KitKat

### DIFF
--- a/app/src/main/scala/chat/tox/antox/av/VideoDisplay.scala
+++ b/app/src/main/scala/chat/tox/antox/av/VideoDisplay.scala
@@ -71,7 +71,7 @@ class Renderer(activity: Activity,
 
   var packedYuv: Array[Int] = _
 
-  var rs: RenderScript = RenderScript.create(activity, RenderScript.ContextType.DEBUG)
+  var rs: RenderScript = _
   var emptyAllocation: Allocation = _
   var yAllocation: Allocation = _
   var uAllocation: Allocation = _
@@ -136,6 +136,12 @@ class Renderer(activity: Activity,
   }
 
   def createScript(surfaceTexture: SurfaceTexture, yStride: Int, uStride: Int, vStride: Int): Unit = {
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
+      rs = RenderScript.create(activity, RenderScript.ContextType.DEBUG)
+    } else {
+      rs = RenderScript.create(activity)
+    }
+
     yuvToRgbScript = new ScriptC_yuvToRgb(rs)
 
     val emptyType = new Type.Builder(rs, Element.U8(rs)).setX(width).setY(height)

--- a/app/src/main/scala/chat/tox/antox/fragments/CommonCallFragment.scala
+++ b/app/src/main/scala/chat/tox/antox/fragments/CommonCallFragment.scala
@@ -61,10 +61,12 @@ abstract class CommonCallFragment extends Fragment {
 
     // power manager used to turn off screen when the proximity sensor is triggered
     powerManager = getActivity.getSystemService(Context.POWER_SERVICE).asInstanceOf[PowerManager]
-    if (powerManager.isWakeLockLevelSupported(PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK)) {
-      maybeWakeLock = Some(powerManager.newWakeLock(
-        PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK,
-        AntoxLog.DEFAULT_TAG.toString))
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+      if (powerManager.isWakeLockLevelSupported(PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK)) {
+        maybeWakeLock = Some(powerManager.newWakeLock(
+          PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK,
+          AntoxLog.DEFAULT_TAG.toString))
+      }
     }
   }
 


### PR DESCRIPTION
The app crashes when I try to (audio) call or receive call.
I got following exceptions
```java
java.lang.NoSuchMethodError: android.os.PowerManager.isWakeLockLevelSupported
                           at chat.tox.antox.fragments.CommonCallFragment.onCreate(CommonCallFragment.scala:64)
                           at chat.tox.antox.fragments.ActiveCallFragment.onCreate(ActiveCallFragment.scala:58)
                           at android.support.v4.app.Fragment.performCreate(Fragment.java:1939)
                           at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:988)
                           at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1207)
                           at android.support.v4.app.BackStackRecord.run(BackStackRecord.java:738)
                           at android.support.v4.app.FragmentManagerImpl.execPendingActions(FragmentManager.java:1572)
                           at android.support.v4.app.FragmentController.execPendingActions(FragmentController.java:330)
                           at android.support.v4.app.FragmentActivity.onStart(FragmentActivity.java:511)
                           at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1163)
                           at android.app.Activity.performStart(Activity.java:5068)
                           at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2109)
                           at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2174)
                           at android.app.ActivityThread.access$700(ActivityThread.java:141)
                           at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1267)
                           at android.os.Handler.dispatchMessage(Handler.java:99)
                           at android.os.Looper.loop(Looper.java:137)
                           at android.app.ActivityThread.main(ActivityThread.java:5059)
                           at java.lang.reflect.Method.invokeNative(Native Method)
                           at java.lang.reflect.Method.invoke(Method.java:511)
                           at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:792)
                           at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:555)
                           at dalvik.system.NativeStart.main(Native Method)
chat.tox.antox/.activities.CallActivity}
```
and
```java
java.lang.NoClassDefFoundError: android.renderscript.RenderScript$ContextType
                           at chat.tox.antox.av.Renderer.<init>(VideoDisplay.scala:74)
                           at chat.tox.antox.av.VideoDisplay.start(VideoDisplay.scala:28)
                           at chat.tox.antox.fragments.ActiveCallFragment$$anonfun$setupVideoUi$1.apply(ActiveCallFragment.scala:261)
                           at chat.tox.antox.fragments.ActiveCallFragment$$anonfun$setupVideoUi$1.apply(ActiveCallFragment.scala:261)
                           at scala.Option.foreach(Option.scala:257)
                           at chat.tox.antox.fragments.ActiveCallFragment.setupVideoUi(ActiveCallFragment.scala:261)
                           at chat.tox.antox.fragments.ActiveCallFragment$$anonfun$onCreateView$12.apply(ActiveCallFragment.scala:199)
                           at chat.tox.antox.fragments.ActiveCallFragment$$anonfun$onCreateView$12.apply(ActiveCallFragment.scala:193)
                           at rx.lang.scala.ImplicitFunctionConversions$$anon$4.call(ImplicitFunctionConversions.scala:73)
                           at rx.Observable$27.onNext(Observable.java:7540)
                           at rx.observers.SafeSubscriber.onNext(SafeSubscriber.java:130)
                           at rx.internal.operators.OperatorObserveOn$ObserveOnSubscriber.pollQueue(OperatorObserveOn.java:208)
                           at rx.internal.operators.OperatorObserveOn$ObserveOnSubscriber$2.call(OperatorObserveOn.java:170)
                           at rx.internal.schedulers.ScheduledAction.run(ScheduledAction.java:55)
                           at android.os.Handler.handleCallback(Handler.java:615)
                           at android.os.Handler.dispatchMessage(Handler.java:92)
                           at android.os.Looper.loop(Looper.java:137)
                           at android.app.ActivityThread.main(ActivityThread.java:5059)
                           at java.lang.reflect.Method.invokeNative(Native Method)
                           at java.lang.reflect.Method.invoke(Method.java:511)
                           at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:792)
                           at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:555)
                           at dalvik.system.NativeStart.main(Native Method)
```
Now with this quick fix the audio calls work great. Tested on Android 4.1.2 and 4.4